### PR TITLE
Change to @vue/cli-service as peerdependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "webpack-merge": "^4.1.2"
   },
   "peerDependencies": {
-    "@vue/cli": "^3.0.1"
+    "@vue/cli-service": "^3.2.0"
   },
   "devDependencies": {
     "@vue/cli-test-utils": "^3.0.1"


### PR DESCRIPTION
As per docs: https://cli.vuejs.org/guide/#cli-service one should depend on the cli-service and not the global cli in their projects, so the current peerDependency throws an unnecessary warning.